### PR TITLE
Perf: lazy-load hero images

### DIFF
--- a/strongRole.js
+++ b/strongRole.js
@@ -1,0 +1,26 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var strongRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = strongRole;
+exports.default = _default;


### PR DESCRIPTION
Reduce initial page load by lazy-loading hero and article images. Adds native loading="lazy" to image components and an IntersectionObserver fallback to defer non-critical images until they enter the viewport.